### PR TITLE
Revert "Add the guide release date"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,6 @@
 :projectid: maven-intro
 :page-layout: guide
 :page-duration: 15 minutes
-:page-date: 2017-09-19
 :page-description: Learn how to build and test a simple web application using Maven and Open Liberty
 :page-tags: ['Maven', 'Getting Started']
 :page-permalink: /guides/{projectid}


### PR DESCRIPTION
Reverts OpenLiberty/guide-maven-intro#20

`page-date` is causing Jekyll build to break.  Another Asciidoctor attribute will be needed to replace `page-date`.  Until we have the new attribute, revert the introduction of `page-date`.