### PR TITLE
Included Try what you'll build section and link to app

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -56,16 +56,11 @@ include::{common-includes}/gitclone.adoc[]
 
 The `finish` directory in the root of this guide contains the finished application. Give it a try before you proceed.
 
-To try out the application, first navigate to the `finish` directory and then run the following
-Maven goal to build the application and run it inside Open Liberty:
-
+To try out the application, first navigate to the `finish` directory and then run the following Maven goals to build the application and run it inside Open Liberty:
 [role='command']
 ```
 mvn install
 ```
-
-This command builds the application and creates a `.war` file in the target directory. It also
-configures and installs Open Liberty into the `target/liberty/wlp` directory.
 
 Next, run the Maven `liberty:start-server` goal:
 [role='command']
@@ -73,18 +68,11 @@ Next, run the Maven `liberty:start-server` goal:
 mvn liberty:start-server
 ```
 
-This goal starts an Open Liberty server instance. Your Maven `pom.xml` is already configured to start
-the application in this server instance.
-
 Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[^]. The application displays a simple web page with the link that, when 
 clicked, calls the servlet to return a simple response of `Hello! How are you today?`.
 
-Once you're done checking out the application, stop the Open Liberty server:
-[role='command']
-```
-mvn liberty:stop-server
-```
-
+[role=command]
+include::{common-includes}/trywhatyoubuild-end.adoc[]
 
 == Creating a simple application
 

--- a/README.adoc
+++ b/README.adoc
@@ -54,7 +54,7 @@ include::{common-includes}/gitclone.adoc[]
 
 include::{common-includes}/trywhatyoubuild-beg.adoc[]
 
-Navigate your browser to the https://localhost:9080/ServletSample/servlet[^] URL to access the application. The servlet returns a simple response of `Hello! How are you today?`.
+Navigate your browser to the http://localhost:9080/ServletSample/servlet[^] URL to access the application. The servlet returns a simple response of `Hello! How are you today?`.
 
 [role=command]
 include::{common-includes}/trywhatyoubuild-end.adoc[]
@@ -202,7 +202,7 @@ include::finish/src/main/liberty/config/server.xml[tags=**;!comment]
 [role='command']
 include::{common-includes}/mvnbuild.adoc[]
 
-Navigate your browser to the https://localhost:9080/ServletSample/servlet[^] URL to access the application. The servlet returns a simple response of `Hello! How are you today?`.
+Navigate your browser to the http://localhost:9080/ServletSample/servlet[^] URL to access the application. The servlet returns a simple response of `Hello! How are you today?`.
 To stop the Open Liberty server, run the Maven `liberty:stop-server` goal: 
 
 [role='command']

--- a/README.adoc
+++ b/README.adoc
@@ -71,7 +71,7 @@ mvn liberty:start-server
 This goal starts an Open Liberty server instance. Your Maven `pom.xml` is already configured to start
 the application in this server instance.
 
-Navigate your browser to this URL to access the application: `https://localhost:9080/ServletSample/servlet`.
+Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[https://localhost:9080/ServletSample/servlet^].
 
 The application displays a simple web page with the link that, when 
 clicked, calls the servlet to return a simple response of `Hello! How are you today?`.

--- a/README.adoc
+++ b/README.adoc
@@ -54,7 +54,7 @@ include::{common-includes}/gitclone.adoc[]
 
 include::{common-includes}/trywhatyoubuild-beg.adoc[]
 
-Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[^]. The application displays a simple web page with the link that, when 
+Navigate your browser to the https://localhost:9080/ServletSample/servlet[^] URL to access the application.  The application displays a simple web page with the link that, when 
 clicked, calls the servlet to return a simple response of `Hello! How are you today?`.
 
 [role=command]
@@ -203,7 +203,7 @@ include::finish/src/main/liberty/config/server.xml[tags=**;!comment]
 [role='command']
 include::{common-includes}/mvnbuild.adoc[]
 
-Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[^]. The application displays a simple web page with the link that, when 
+Navigate your browser to the https://localhost:9080/ServletSample/servlet[^] URL to access the application.  The application displays a simple web page with the link that, when 
 clicked, calls the servlet to return a simple response of `Hello! How are you today?`.
 
 To stop the Open Liberty server, run the Maven `liberty:stop-server` goal: 

--- a/README.adoc
+++ b/README.adoc
@@ -52,21 +52,7 @@ and configure Maven to run it after building the application.
 [role='command']
 include::{common-includes}/gitclone.adoc[]
 
-=== Try what you'll build
-
-The `finish` directory in the root of this guide contains the finished application. Give it a try before you proceed.
-
-To try out the application, first navigate to the `finish` directory and then run the following Maven goals to build the application and run it inside Open Liberty:
-[role='command']
-```
-mvn install
-```
-
-Next, run the Maven `liberty:start-server` goal:
-[role='command']
-```
-mvn liberty:start-server
-```
+include::{common-includes}/trywhatyoubuild-beg.adoc[]
 
 Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[^]. The application displays a simple web page with the link that, when 
 clicked, calls the servlet to return a simple response of `Hello! How are you today?`.

--- a/README.adoc
+++ b/README.adoc
@@ -52,6 +52,36 @@ and configure Maven to run it after building the application.
 [role='command']
 include::{common-includes}/gitclone.adoc[]
 
+=== Try what you'll build
+To try out the application, first navigate to the `finish` directory and then run the following Maven goals to build the application and run it inside Open Liberty:
+
+```
+mvn install
+```
+
+This command builds the application and creates a `.war` file in the target directory. It also
+configures and installs Open Liberty into the `target/liberty/wlp` directory.
+
+Next, run the Maven `liberty:start-server` goal:
+
+```
+mvn liberty:start-server
+```
+
+This goal starts an Open Liberty server instance. Your Maven `pom.xml` is already configured to start
+the application in this server instance.
+
+Navigate your browser to this URL to access the application: `https://localhost:9080/ServletSample/servlet`.
+
+The application displays a simple web page with the link that, when 
+clicked, calls the servlet to return a simple response of `Hello! How are you today?`.
+
+Once you're done checking out the application, stop the Open Liberty server:
+```
+mvn liberty:stop-server
+```
+
+
 == Creating a simple application
 
 The simple web application that you will build using Maven and Open Liberty is provided 

--- a/README.adoc
+++ b/README.adoc
@@ -71,9 +71,7 @@ mvn liberty:start-server
 This goal starts an Open Liberty server instance. Your Maven `pom.xml` is already configured to start
 the application in this server instance.
 
-Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[https://localhost:9080/ServletSample/servlet^].
-
-The application displays a simple web page with the link that, when 
+Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[https://localhost:9080/ServletSample/servlet^]. The application displays a simple web page with the link that, when 
 clicked, calls the servlet to return a simple response of `Hello! How are you today?`.
 
 Once you're done checking out the application, stop the Open Liberty server:
@@ -243,9 +241,7 @@ mvn liberty:start-server
 This goal starts an Open Liberty server instance. Your Maven `pom.xml` is already configured to start
 the application in this server instance.
 
-Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[https://localhost:9080/ServletSample/servlet^].
-
-The application displays a simple web page with the link that, when 
+Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[https://localhost:9080/ServletSample/servlet^]. The application displays a simple web page with the link that, when 
 clicked, calls the servlet to return a simple response of `Hello! How are you today?`.
 
 To stop the Open Liberty server, run the Maven `liberty:stop-server` goal: 

--- a/README.adoc
+++ b/README.adoc
@@ -53,7 +53,12 @@ and configure Maven to run it after building the application.
 include::{common-includes}/gitclone.adoc[]
 
 === Try what you'll build
-To try out the application, first navigate to the `finish` directory and then run the following Maven goals to build the application and run it inside Open Liberty:
+
+The `finish` directory in the root of this guide contains the finished application. Give it a try before you proceed.
+
+To try out the application, first navigate to the `finish` directory and then run the following
+Maven goal to build the application and run it inside Open Liberty:
+
 [role='command']
 ```
 mvn install
@@ -71,7 +76,7 @@ mvn liberty:start-server
 This goal starts an Open Liberty server instance. Your Maven `pom.xml` is already configured to start
 the application in this server instance.
 
-Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[https://localhost:9080/ServletSample/servlet^]. The application displays a simple web page with the link that, when 
+Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[^]. The application displays a simple web page with the link that, when 
 clicked, calls the servlet to return a simple response of `Hello! How are you today?`.
 
 Once you're done checking out the application, stop the Open Liberty server:
@@ -223,25 +228,10 @@ include::finish/src/main/liberty/config/server.xml[tags=**;!comment]
 
 == Building and running the application
 
-To build the application, run the Maven `install` phase from the command line in the `start` directory:
 [role='command']
-```
-mvn install
-```
+include::{common-includes}/mvnbuild.adoc[]
 
-This command builds the application and creates a `.war` file in the target directory. It also
-configures and installs Open Liberty into the `target/liberty/wlp` directory.
-
-Next, run the Maven `liberty:start-server` goal:
-[role='command']
-```
-mvn liberty:start-server
-```
-
-This goal starts an Open Liberty server instance. Your Maven `pom.xml` is already configured to start
-the application in this server instance.
-
-Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[https://localhost:9080/ServletSample/servlet^]. The application displays a simple web page with the link that, when 
+Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[^]. The application displays a simple web page with the link that, when 
 clicked, calls the servlet to return a simple response of `Hello! How are you today?`.
 
 To stop the Open Liberty server, run the Maven `liberty:stop-server` goal: 

--- a/README.adoc
+++ b/README.adoc
@@ -54,7 +54,7 @@ include::{common-includes}/gitclone.adoc[]
 
 include::{common-includes}/trywhatyoubuild-beg.adoc[]
 
-Navigate your browser to the https://localhost:9080/ServletSample/servlet[^] URL to access the application. The application displays a webpage with a link that calls the servlet to return a simple response of `Hello! How are you today?`.
+Navigate your browser to the https://localhost:9080/ServletSample/servlet[^] URL to access the application. The servlet returns a simple response of `Hello! How are you today?`.
 
 [role=command]
 include::{common-includes}/trywhatyoubuild-end.adoc[]
@@ -202,9 +202,7 @@ include::finish/src/main/liberty/config/server.xml[tags=**;!comment]
 [role='command']
 include::{common-includes}/mvnbuild.adoc[]
 
-Navigate your browser to the https://localhost:9080/ServletSample/servlet[^] URL to access the application.  The application displays a simple web page with the link that, when 
-clicked, calls the servlet to return a simple response of `Hello! How are you today?`.
-
+Navigate your browser to the https://localhost:9080/ServletSample/servlet[^] URL to access the application. The servlet returns a simple response of `Hello! How are you today?`.
 To stop the Open Liberty server, run the Maven `liberty:stop-server` goal: 
 
 [role='command']

--- a/README.adoc
+++ b/README.adoc
@@ -54,7 +54,7 @@ include::{common-includes}/gitclone.adoc[]
 
 === Try what you'll build
 To try out the application, first navigate to the `finish` directory and then run the following Maven goals to build the application and run it inside Open Liberty:
-
+[role='command']
 ```
 mvn install
 ```
@@ -63,7 +63,7 @@ This command builds the application and creates a `.war` file in the target dire
 configures and installs Open Liberty into the `target/liberty/wlp` directory.
 
 Next, run the Maven `liberty:start-server` goal:
-
+[role='command']
 ```
 mvn liberty:start-server
 ```
@@ -77,6 +77,7 @@ The application displays a simple web page with the link that, when
 clicked, calls the servlet to return a simple response of `Hello! How are you today?`.
 
 Once you're done checking out the application, stop the Open Liberty server:
+[role='command']
 ```
 mvn liberty:stop-server
 ```
@@ -222,8 +223,30 @@ server.xml
 include::finish/src/main/liberty/config/server.xml[tags=**;!comment]
 ----
 
+== Building and running the application
+
+To build the application, run the Maven `install` phase from the command line in the `start` directory:
 [role='command']
-include::{common-includes}/mvnbuild.adoc[]
+```
+mvn install
+```
+
+This command builds the application and creates a `.war` file in the target directory. It also
+configures and installs Open Liberty into the `target/liberty/wlp` directory.
+
+Next, run the Maven `liberty:start-server` goal:
+[role='command']
+```
+mvn liberty:start-server
+```
+
+This goal starts an Open Liberty server instance. Your Maven `pom.xml` is already configured to start
+the application in this server instance.
+
+Navigate your browser to this URL to access the application: https://localhost:9080/ServletSample/servlet[https://localhost:9080/ServletSample/servlet^].
+
+The application displays a simple web page with the link that, when 
+clicked, calls the servlet to return a simple response of `Hello! How are you today?`.
 
 To stop the Open Liberty server, run the Maven `liberty:stop-server` goal: 
 

--- a/README.adoc
+++ b/README.adoc
@@ -54,8 +54,7 @@ include::{common-includes}/gitclone.adoc[]
 
 include::{common-includes}/trywhatyoubuild-beg.adoc[]
 
-Navigate your browser to the https://localhost:9080/ServletSample/servlet[^] URL to access the application.  The application displays a simple web page with the link that, when 
-clicked, calls the servlet to return a simple response of `Hello! How are you today?`.
+Navigate your browser to the https://localhost:9080/ServletSample/servlet[^] URL to access the application. The application displays a webpage with a link that calls the servlet to return a simple response of `Hello! How are you today?`.
 
 [role=command]
 include::{common-includes}/trywhatyoubuild-end.adoc[]

--- a/README.adoc
+++ b/README.adoc
@@ -200,8 +200,6 @@ server.xml
 include::finish/src/main/liberty/config/server.xml[tags=**;!comment]
 ----
 
-== Building and running the application
-
 [role='command']
 include::{common-includes}/mvnbuild.adoc[]
 


### PR DESCRIPTION
Updated README.adoc to include a `Try what you'll build` section and a link to the application servlet. Addressing https://github.com/OpenLiberty/guide-maven-intro/issues/49.