### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,18 @@
+name: Add PRs to Dependabot PRs dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add PR to dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/26
+          github-token: ${{ secrets.ADMIN_BACKLOG }}
+          labeled: dependencies

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corporation and others.
+// Copyright (c) 2017, 2024 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -15,7 +15,7 @@
 :page-essential-order: 3
 :page-description: Learn how to build and test a simple web application using Maven and Open Liberty
 :page-related-guides: ['maven-multimodules', 'gradle-intro']
-:page-tags: ['Maven']
+:page-tags: ['maven']
 :page-permalink: /guides/{projectid}
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/prod
 :page-seo-title: Building and testing a Java web application with Maven and Open Liberty

--- a/README.adoc
+++ b/README.adoc
@@ -178,7 +178,7 @@ The project coordinates describe the name and version of the application. The [h
 
 The first four properties in the properties section of the project, just define the encoding ([hotspot=encoding file=0]`UTF-8`) and version of Java ([hotspot=java-version file=0]`Java 11`) that Maven uses to compile the application source code.
 
-Open Liberty configuration properties provide you with a single place to specify values that are used in multiple places throughout the application. For example, the [hotspot=default-http-port file=0]`default.http.port` value is used in both the Liberty [hotspot=httpEndpoint file=2]`server.xml` configuration file and will be used in the test class that you will add (`EndpointIT.java`) to the application. Because the [hotspot=default-http-port file=0]`default.http.port` value is specified in the [hotspot file=0]`pom.xml` file, you can easily change the port number that the Liberty instance runs on without updating the application code in multiple places.
+Open Liberty configuration properties provide you with a single place to specify values that are used in multiple places throughout the application. For example, the [hotspot=http.port file=0]`http.port` value is used in both the Liberty [hotspot=httpEndpoint file=2]`server.xml` configuration file and will be used in the test class that you will add (`EndpointIT.java`) to the application. Because the [hotspot=http.port file=0]`http.port` value is specified in the [hotspot file=0]`pom.xml` file, you can easily change the port number that the Liberty instance runs on without updating the application code in multiple places.
 
 HelloServlet.java
 [source, java, linenums, role='code_column hide_tags=comment,javadoc1,javadoc2']

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -26,10 +26,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <!-- end::java-version[] -->
         <!-- Liberty configuration -->
-        <!-- tag::default-http-port[] -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <!-- end::default-http-port[] -->
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <!-- tag::http.port[] -->
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <!-- end::http.port[] -->
+        <liberty.var.https.port>9443</liberty.var.https.port>
         <liberty.var.app.context.root>${project.artifactId}</liberty.var.app.context.root>
     </properties>
     <!-- end::properties[] -->
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <!-- tag::test2[] -->
             <scope>test</scope>
             <!-- end::test2[] -->
@@ -97,7 +97,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
                 <!-- tag::configuration[] -->
                 <configuration>
                     <!-- tag::serverName[] -->
@@ -111,12 +111,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <!-- tag::system-property-variables[] -->
                     <systemPropertyVariables>
                         <!-- tag::http-port[] -->
-                        <http.port>${liberty.var.default.http.port}</http.port>
+                        <http.port>${liberty.var.http.port}</http.port>
                         <!-- end::http-port[] -->
                         <!-- tag::war-name[] -->
                         <war.name>${liberty.var.app.context.root}</war.name>

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -3,13 +3,13 @@
         <feature>servlet-6.0</feature>
     </featureManager>
 
-    <variable name="default.http.port" defaultValue="9080"/>
-    <variable name="default.https.port" defaultValue="9443"/>
+    <variable name="http.port" defaultValue="9080"/>
+    <variable name="https.port" defaultValue="9443"/>
     <variable name="app.context.root" defaultValue="ServletSample"/>
 
     <!-- tag::httpEndpoint[] -->
-    <httpEndpoint httpPort="${default.http.port}" 
-    httpsPort="${default.https.port}" id="defaultHttpEndpoint"  host="*" />
+    <httpEndpoint httpPort="${http.port}" 
+    httpsPort="${https.port}" id="defaultHttpEndpoint"  host="*" />
     <!-- end::httpEndpoint[] -->
     <webApplication id="ServletSample" location="ServletSample.war" contextRoot="${app.context.root}" />
 </server>

--- a/scripts/dailyBuild.sh
+++ b/scripts/dailyBuild.sh
@@ -8,7 +8,7 @@ do
     esac
 done
 
-sed -i "\#<artifactId>liberty-maven-plugin</artifactId>#,\#<configuration>#c<artifactId>liberty-maven-plugin</artifactId><version>3.7.1</version><configuration><install><runtimeUrl>https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/$DATE/$DRIVER</runtimeUrl></install>" pom.xml
+sed -i "\#<artifactId>liberty-maven-plugin</artifactId>#,\#<configuration>#c<artifactId>liberty-maven-plugin</artifactId><version>3.10</version><configuration><install><runtimeUrl>https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/$DATE/$DRIVER</runtimeUrl></install>" pom.xml
 cat pom.xml
 
 ../scripts/testApp.sh

--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -3,13 +3,13 @@
         <feature>servlet-6.0</feature>
     </featureManager>
 
-    <variable name="default.http.port" defaultValue="9080"/>
-    <variable name="default.https.port" defaultValue="9443"/>
+    <variable name="http.port" defaultValue="9080"/>
+    <variable name="https.port" defaultValue="9443"/>
     <variable name="app.context.root" defaultValue="ServletSample"/>
 
     <!-- tag::httpEndpoint[] -->
-    <httpEndpoint httpPort="${default.http.port}" 
-    httpsPort="${default.https.port}" id="defaultHttpEndpoint"  host="*" />
+    <httpEndpoint httpPort="${http.port}" 
+    httpsPort="${https.port}" id="defaultHttpEndpoint"  host="*" />
     <!-- end::httpEndpoint[] -->
     <webApplication id="ServletSample" location="ServletSample.war" contextRoot="${app.context.root}" />
 </server>


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

